### PR TITLE
Add target-platform option

### DIFF
--- a/.github/workflows/project-builder.yml
+++ b/.github/workflows/project-builder.yml
@@ -22,6 +22,11 @@ on:
         type: string
         description: "Relative path from project root to F´ submodule"
         default: "./fprime"
+      target_platform:
+        required: false
+        type: string
+        description: "F´ build platform (e.g. Linux, Darwin). Default specified in settings.ini."
+        default: ""
       runs_on:
         required: false
         type: string

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Choosing between using the reusable workflow or composite action can be a matter
 | fprime_version  |                | F´ version to use (branch or tag). Defaults to the version pointed to by the project submodule.|
 | fprime_location | `./fprime`     | Relative path from project root to F´ submodule|
 | runs_on         | `ubuntu-latest`| Platform to run on. Defaults to ubuntu-latest|
+| target_platform |                | F´ build platform (e.g. Linux, Darwin). Default specified in settings.ini.|
 
 
 ## Workflow Example

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,10 @@ inputs:
     description: "Run a Unit Test build (--ut) instead of a normal build [true|false] (default: false)"
     required: false
     default: "false"
+  target_platform:
+    description: "F´ build platform (e.g. Linux, Darwin). Default specified in settings.ini."
+    required: false
+    default: ""
 
 runs:
   using: "composite"
@@ -33,14 +37,14 @@ runs:
     - if: ${{ inputs.run_unit_tests }} == "false"
       working-directory: ${{ inputs.build_location }}
       run: |
-        fprime-util generate
-        fprime-util build
+        fprime-util generate ${{ inputs.target_platform }}
+        fprime-util build ${{ inputs.target_platform }}
       shell: bash
     - if: ${{ inputs.run_unit_tests }} == "true"
       working-directory: ${{ inputs.build_location }}
       run: |
-        fprime-util generate --ut
-        fprime-util build --ut
-        fprime-util check
+        fprime-util generate --ut ${{ inputs.target_platform }}
+        fprime-util build --ut ${{ inputs.target_platform }}
+        fprime-util check ${{ inputs.target_platform }}
       shell: bash
 


### PR DESCRIPTION
This PR adds `target-platform` as an option to both the composite action and the reusable workflow (looks like it was partially completed in the reusable workflow).

We need the ability to select the build target in our work on an fprime deployment for an rp2040.

Thanks for taking a look, please let me know if you have any feedback!

FYI @thomas-bc 