### PR TITLE
Remove `target_platform` from test section of composite action and reusable workflow

### DIFF
--- a/.github/workflows/project-builder.yml
+++ b/.github/workflows/project-builder.yml
@@ -84,16 +84,16 @@ jobs:
       - name: "Generate UT build cache"
         working-directory: ${{ inputs.build_location }}
         run: |
-          fprime-util generate --ut ${{ runner.debug == '1' && '--verbose' || '' }} ${{ inputs.target_platform }}
+          fprime-util generate --ut ${{ runner.debug == '1' && '--verbose' || '' }}
         shell: bash
       - name: "Build UTs"
         working-directory: ${{ inputs.build_location }}
         run: |
-          fprime-util build --ut ${{ runner.debug == '1' && '--verbose' || '' }} ${{ inputs.target_platform }}
+          fprime-util build --ut ${{ runner.debug == '1' && '--verbose' || '' }}
         shell: bash
       - name: "Run Unit Tests"
         working-directory: ${{ inputs.build_location }}
         run: |
-          fprime-util check ${{ runner.debug == '1' && '--verbose' || '' }} ${{ inputs.target_platform }}
+          fprime-util check ${{ runner.debug == '1' && '--verbose' || '' }}
         shell: bash
 

--- a/action.yml
+++ b/action.yml
@@ -43,8 +43,8 @@ runs:
     - if: ${{ inputs.run_unit_tests }} == "true"
       working-directory: ${{ inputs.build_location }}
       run: |
-        fprime-util generate --ut ${{ inputs.target_platform }}
-        fprime-util build --ut ${{ inputs.target_platform }}
-        fprime-util check ${{ inputs.target_platform }}
+        fprime-util generate --ut
+        fprime-util build --ut
+        fprime-util check
       shell: bash
 


### PR DESCRIPTION
Follow up to #1 based on [feedback](https://github.com/fprime-community/project-builder/pull/1#issuecomment-2293743261)

This PR removes the `target_platform` input from the test sections of both the composite action and the reusable workflow.