### PR TITLE
Fix conditional evaluation

### DIFF
--- a/.github/workflows/project-builder.yml
+++ b/.github/workflows/project-builder.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
-      - if: ${{ inputs.fprime_version }} != ""
+      - if: inputs.fprime_version != ''
         name: "Checkout F´ Version"
         run: |
           cd ${{ inputs.fprime_location }}
@@ -72,7 +72,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
-      - if: ${{ inputs.fprime_version }} != ""
+      - if: inputs.fprime_version != ''
         name: "Checkout F´ Version"
         run: |
           cd ${{ inputs.fprime_location }}

--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - if: ${{ inputs.fprime_version }} != ""
+    - if: inputs.fprime_version != ''
       run: |
         cd ${{ inputs.fprime_location }}
         git checkout ${{ inputs.fprime_version }}
@@ -34,13 +34,13 @@ runs:
     - run: |
         pip3 install -r ${{ inputs.fprime_location }}/requirements.txt
       shell: bash
-    - if: ${{ inputs.run_unit_tests }} == "false"
+    - if: inputs.run_unit_tests == 'false'
       working-directory: ${{ inputs.build_location }}
       run: |
         fprime-util generate ${{ inputs.target_platform }}
         fprime-util build ${{ inputs.target_platform }}
       shell: bash
-    - if: ${{ inputs.run_unit_tests }} == "true"
+    - if: inputs.run_unit_tests == 'true'
       working-directory: ${{ inputs.build_location }}
       run: |
         fprime-util generate --ut


### PR DESCRIPTION
I found that tests were always running when including the composite action in my workflow. It looks like when using `if: ${{ <expression> }}` in a step, the entire expression either needs to be wrapped or unwrapped. Additionally I found when wrapping the entire expression I hit the following issue:
> You don't need to enclose strings in ${{ and }}. However, if you do, you must use single quotes (') around the string. To use a literal single quote, escape the literal single quote using an additional single quote (''). Wrapping with double quotes (") will throw an error.
[Expressions in workflows](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions)

Even though I've gone with unwrapped expressions (up to you on style?) I left the single quotes for string representation.

FYI @thomas-bc 